### PR TITLE
Fix location that Actions badge was referring to

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Remote Workstation ☁️🌎📦 ![CI Status](https://github.com/developmentseed/remote-workstation/.github/workflows/ci.yml/badge.svg)
+# Remote Workstation ☁️🌎📦 ![CI Status](https://github.com/developmentseed/remote-workstation/actions/workflows/ci.yml/badge.svg)
 
 
 This project aims to enable the deployment of a dockerised workstation that can be SSH'd into


### PR DESCRIPTION
## What I am changing

I miss-read the instructions on https://docs.github.com/en/actions/managing-workflow-runs/adding-a-workflow-status-badge so I'm fixing the path

## How I did it

* Changed the path to `https://github.com/developmentseed/remote-workstation/actions/workflows/ci.yml/badge.svg`

## How you can test it

Checkout this: ![CI Status](https://github.com/developmentseed/remote-workstation/actions/workflows/ci.yml/badge.svg) which is the same path 🥳 